### PR TITLE
chore(ci): Bump CI environment and dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '37 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +32,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -71,7 +69,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -83,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -105,7 +103,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -117,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -139,7 +137,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 
     "require-dev"       : {
         "jbzoo/toolbox-dev" : "^7.1",
-        "jbzoo/codestyle"   : "^7.1.4",
+        "jbzoo/codestyle"   : "^7.1.5",
         "jbzoo/http-client" : "^7.1",
         "jbzoo/data"        : "^7.1",
         "jbzoo/utils"       : "^7.2",


### PR DESCRIPTION
- Remove scheduled workflow trigger.
- Update PHP matrix to include 8.4 and drop 8.1.
- Upgrade `actions/upload-artifact` to v4.
- Update `jbzoo/codestyle` dev dependency to `^7.1.5`.