### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/JBZoo/PHPUnit/security/code-scanning/8](https://github.com/JBZoo/PHPUnit/security/code-scanning/8)

The proper way to address this is to add a `permissions` block at either the workflow or job level, specifying the least privilege required. Because there is no evidence that any step in any job needs write permissions, and most steps only require how to checkout code or upload artifacts, setting the minimal feasible permission (`contents: read`) at the workflow level makes sense. This will apply to all jobs (`phpunit`, `linters`, `report`) and can be overridden in any individual job if necessary in the future. To implement, add:

```yaml
permissions:
  contents: read
```

immediately after the workflow `name:` declaration (line 13). No further code, imports, or modifications are required, as this is a YAML/metadata configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
