### PR TITLE
fix(ci): Grant read permissions for workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 
     "require-dev"       : {
         "jbzoo/toolbox-dev" : "^7.1",
-        "jbzoo/codestyle"   : "^7.1.5",
+        "jbzoo/codestyle"   : "^7.1.6",
         "jbzoo/http-client" : "^7.1",
         "jbzoo/data"        : "^7.1",
         "jbzoo/utils"       : "^7.2",


### PR DESCRIPTION
- Add `contents: read` permission to the GitHub Actions workflow to ensure proper access for actions.
- Update `jbzoo/codestyle` development dependency from `^7.1.5` to `^7.1.6`.