### PR TITLE
build(phpunit): Bump PHPUnit to v11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-filter"          : "*",
         "ext-mbstring"        : "*",
 
-        "phpunit/phpunit"     : "^9.6.29",
+        "phpunit/phpunit"     : "^11.5.41",
         "ulrichsg/getopt-php" : ">=4.0.4",
         "jbzoo/markdown"      : "^7.0.1"
     },

--- a/src/CovCatcher.php
+++ b/src/CovCatcher.php
@@ -122,7 +122,7 @@ final class CovCatcher
     {
         if (!$this->isStarted) {
             $this->isStarted = true;
-            $this->coverage?->start($this->hash, true);
+            $this->coverage?->start($this->hash, null, true);
         }
     }
 
@@ -188,8 +188,10 @@ final class CovCatcher
     {
         $covFilter = new Filter();
 
-        foreach ((new FileIteratorFacade())->getFilesAsArray($dirPath, '.php') as $file) {
-            $covFilter->includeFile($file);
+        if ($dirPath !== '') {
+            foreach ((new FileIteratorFacade())->getFilesAsArray($dirPath, '.php') as $file) {
+                $covFilter->includeFile($file);
+            }
         }
 
         return $covFilter;


### PR DESCRIPTION
- Upgrades `phpunit/phpunit` from `^9.6.29` to `^11.5.41`.
- Adjusts `CovCatcher::start` to match the updated `php-code-coverage` API, now requiring `null` for the second argument.
- Adds a check in `CovCatcher::getCoverageFilter` to prevent attempting to include files from an empty directory path.